### PR TITLE
Evaluate connection parameters at runtime

### DIFF
--- a/lib/moebius/runner.ex
+++ b/lib/moebius/runner.ex
@@ -3,14 +3,13 @@ defmodule Moebius.Runner do
   The main execution bits are in here.
   """
 
-  @opts Application.get_env(:moebius, :connection)
-
   @doc """
   Spawn a Postgrex worker to run our query using the config specified in /config
   """
   def connect do
     extensions = [{Postgrex.Extensions.JSON, library: Poison}]
-    @opts
+    
+    Application.get_env(:moebius, :connection)
     |> Keyword.update(:extensions, extensions, &(&1 ++ extensions))
     |> Postgrex.Connection.start_link
   end


### PR DESCRIPTION
Using `@opts` was causing the connection parameters to be evaluated solely at compile time, which is undesirable behavior in certain cases (such as when the database is indicated at runtime).
